### PR TITLE
Initial setup for Backstage deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# backstage-deployment-gke
-Initial setup for Backstage deployment
+# Backstage Deployment
+
+This repository contains a Helm chart for deploying Backstage on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm installed
+
+## Deployment
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/yourusername/backstage-deployment.git
+   cd backstage-deployment
+
+## Install the Helm chart:
+
+    helm install backstage charts/backstage
+    
+## Access Backstage:
+
+    URL: https://backstage.example.com

--- a/backstage-deployment/.gitignore
+++ b/backstage-deployment/.gitignore
@@ -1,0 +1,4 @@
+# Add any files or directories you want to ignore
+node_modules/
+dist/
+.env

--- a/backstage-deployment/charts/backstage/Chart.yaml
+++ b/backstage-deployment/charts/backstage/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: backstage
+description: A Helm chart for deploying Backstage
+version: 0.1.0
+appVersion: latest

--- a/backstage-deployment/charts/backstage/templates/configmap.yaml
+++ b/backstage-deployment/charts/backstage/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-config
+data:
+  app-config.yaml: |
+    app:
+      baseUrl: {{ .Values.appConfig.app.baseUrl }}
+    backend:
+      baseUrl: {{ .Values.appConfig.backend.baseUrl }}
+      listen:
+        port: {{ .Values.appConfig.backend.listen.port }}
+    database:
+      client: {{ .Values.appConfig.database.client }}
+      connection:
+        host: {{ .Values.appConfig.database.connection.host }}
+        port: {{ .Values.appConfig.database.connection.port }}
+        user: {{ .Values.appConfig.database.connection.user }}
+        password: {{ .Values.appConfig.database.connection.password }}
+        database: {{ .Values.appConfig.database.connection.database }}
+    techdocs:
+      builder: {{ .Values.appConfig.techdocs.builder }}
+      publisher:
+        type: {{ .Values.appConfig.techdocs.publisher.type }}
+        local:
+          storagePath: {{ .Values.appConfig.techdocs.publisher.local.storagePath }}
+    auth:
+      environment: {{ .Values.appConfig.auth.environment }}
+      providers:
+        google:
+          clientId: {{ .Values.appConfig.auth.providers.google.clientId }}
+          clientSecret: {{ .Values.appConfig.auth.providers.google.clientSecret }}

--- a/backstage-deployment/charts/backstage/values.yaml
+++ b/backstage-deployment/charts/backstage/values.yaml
@@ -1,0 +1,53 @@
+replicas: 1
+image:
+  registry: ghcr.io
+  repository: backstage/backstage
+  tag: latest
+  pullPolicy: Always
+containerPorts:
+  backend: 7007
+appConfig:
+  app:
+    baseUrl: https://backstage.example.com
+  backend:
+    baseUrl: https://backstage.example.com/api
+    listen:
+      port: 7007
+  database:
+    client: pg
+    connection:
+      host: backstage-postgresql
+      port: 5432
+      user: default_user
+      password: default_password
+      database: default_db
+  techdocs:
+    builder: 'local'
+    publisher:
+      type: 'local'
+      local:
+        storagePath: /tmp/techdocs
+  auth:
+    environment: production
+    providers:
+      google:
+        clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+extraEnvVars:
+- name: AUTH_GOOGLE_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: backstage-secrets
+      key: AUTH_GOOGLE_CLIENT_ID
+- name: AUTH_GOOGLE_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: backstage-secrets
+      key: AUTH_GOOGLE_CLIENT_SECRET
+extraEnvVarsSecrets:
+- backstage-secrets
+ingress:
+  host: backstage.example.com
+  tls:
+    enabled: true
+    secretName: backstage-tls


### PR DESCRIPTION
This PR includes the initial setup for deploying Backstage using Kubernetes. The following changes are introduced:

- Added Helm chart for Backstage deployment.
- Configured necessary environment variables and secrets.
- Included health checks for liveness, readiness, and startup probes.
- Set up PostgreSQL as the backend database.

The Backstage instance will be accessible at https://backstage.example.com.

### How to Test

1. Clone the repository:
git clone https://github.com/yourusername/backstage-deployment.git

2. Navigate to the project directory:
cd backstage-deployment


3. Create a Kubernetes cluster if you don't already have one.

4. Deploy the Helm chart:
helm install backstage charts/backstage


5. Verify the deployment by accessing the Backstage URL.

### Notes

- Replace `example.com` with your actual domain.
- Ensure that your Kubernetes cluster is properly configured with necessary permissions.
- Update the environment variables and secrets according to your specific setup.

Descrição do Backstage
Backstage é uma plataforma de código aberto desenvolvida pela Spotify que ajuda a gerenciar e escalar a infraestrutura de engenharia de software. Ele proporciona uma interface unificada para acessar serviços e ferramentas internas, documentar APIs e gerenciar dados de operações.